### PR TITLE
Fixed link cost calculation

### DIFF
--- a/src/main/java/net/floodlightcontroller/topology/TopologyInstance.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyInstance.java
@@ -748,7 +748,7 @@ public class TopologyInstance {
 
                     if ((bpsTx / 10^6) / 8 > 1) {
                         int cost = (int) (bpsTx / 10^6) / 8;
-                        linkCost.put(link, ((1/cost)*1000));
+                        linkCost.put(link, cost);
                     } else {
                         linkCost.put(link, MAX_LINK_WEIGHT);
                     }


### PR DESCRIPTION
Fix for link cost calculation into TopologyInstance for the metric "utilization". It was an erroneous copy-paste from the link-speed case.